### PR TITLE
added snapcraft recipe

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ version: '0.1'
 summary: Commandline tool for converting between several e-books formats
 description: |
   Commandline tool for converting between several e-books formats, based on Calibre 
-project.
+  project.
 
 grade: stable 
 confinement: strict 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: ebook-converter 
+base: core18 
+version: '0.1' 
+summary: Commandline tool for converting between several e-books formats
+description: |
+  Commandline tool for converting between several e-books formats, based on Calibre 
+project.
+
+grade: stable 
+confinement: strict 
+
+parts:
+  ebook-convert:
+    build-packages:
+      - build-essential
+      - pkg-config
+      - libxml2-dev
+    plugin: python
+    python-version: python3
+    source: https://github.com/gryf/ebook-converter.git
+
+apps:
+  ebook-converter:
+   command: bin/ebook-converter
+   plugs:
+        - home
+        - mount-observe


### PR DESCRIPTION
I just created Snapcraft recipe for this project, this commit will allow the package to auto build and get published in snapstore using snapcraft build service (if hooked to a registered snap at https://snapcraft.io/).

I tested and build it my self with `snapcraft remote-build`. 
On successful build, you will get a snap of size 19Mb downloaded in the build directory. 
You can install to try it using `snap install ebook-converter_0.1_amd64.snap --dangerous`.

Though there is an issue while running the application.

**The issue while running app:**
```
Traceback (most recent call last):
  File "/snap/ebook-converter/x1/bin/ebook-converter", line 33, in <module>
    sys.exit(load_entry_point('ebook-converter==4.12.0', 'console_scripts', 'ebook-converter')())
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/pkg_resources/__init__.py", line 488, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2861, in load_entry_point
    return ep.load()
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2461, in load
    return self.resolve()
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2467, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/ebook_converter/main.py", line 4, in <module>
    from ebook_converter.ebooks.conversion.cli import main
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/ebook_converter/ebooks/conversion/cli.py", line 12, in <module>
    from ebook_converter.utils.config import OptionParser
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/ebook_converter/utils/config.py", line 10, in <module>
    from ebook_converter.utils.config_base import (
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/ebook_converter/utils/config_base.py", line 570, in <module>
    prefs['installation_uuid'] = str(uuid.uuid4())
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/ebook_converter/utils/config_base.py", line 464, in __setitem__
    return self.set(key, val)
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/ebook_converter/utils/config_base.py", line 478, in set
    return self.__config.set(key, val)
  File "/snap/ebook-converter/x1/lib/python3.6/site-packages/ebook_converter/utils/config_base.py", line 406, in set
    with open(self.config_file_path) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/bulld/snap/ebook-converter/x1/.config/calibre/global.py.json'

```

In the issue above app is looking for  ~/.config/calibre/global.py.json which is not present there. Am not a python expert so I can not help in this too much but. I like your project and I was looking for something like this today. 


 