### PR TITLE
Fix unsmarten text option

### DIFF
--- a/ebook_converter/ebooks/oeb/transforms/unsmarten.py
+++ b/ebook_converter/ebooks/oeb/transforms/unsmarten.py
@@ -1,0 +1,27 @@
+__license__ = 'GPL 3'
+__copyright__ = '2011, John Schember <john@nachtimwald.com>'
+__docformat__ = 'restructuredtext en'
+
+from calibre.ebooks.oeb.base import OEB_DOCS, XPath, barename
+from calibre.utils.unsmarten import unsmarten_text
+
+
+class UnsmartenPunctuation:
+
+    def __init__(self):
+        self.html_tags = XPath('descendant::h:*')
+
+    def unsmarten(self, root):
+        for x in self.html_tags(root):
+            if not barename(x.tag) == 'pre':
+                if getattr(x, 'text', None):
+                    x.text = unsmarten_text(x.text)
+                if getattr(x, 'tail', None) and x.tail:
+                    x.tail = unsmarten_text(x.tail)
+
+    def __call__(self, oeb, context):
+        bx = XPath('//h:body')
+        for x in oeb.manifest.items:
+            if x.media_type in OEB_DOCS:
+                for body in bx(x.data):
+                    self.unsmarten(body)

--- a/ebook_converter/ebooks/oeb/transforms/unsmarten.py
+++ b/ebook_converter/ebooks/oeb/transforms/unsmarten.py
@@ -2,7 +2,8 @@ __license__ = 'GPL 3'
 __copyright__ = '2011, John Schember <john@nachtimwald.com>'
 __docformat__ = 'restructuredtext en'
 
-from ebook_converter.ebooks.oeb.base import OEB_DOCS, XPath, barename
+from ebook_converter.ebooks.oeb.base import OEB_DOCS, XPath
+from ebook_converter.ebooks.oeb.parse_utils import barename
 from ebook_converter.utils.unsmarten import unsmarten_text
 
 

--- a/ebook_converter/ebooks/oeb/transforms/unsmarten.py
+++ b/ebook_converter/ebooks/oeb/transforms/unsmarten.py
@@ -2,8 +2,8 @@ __license__ = 'GPL 3'
 __copyright__ = '2011, John Schember <john@nachtimwald.com>'
 __docformat__ = 'restructuredtext en'
 
-from calibre.ebooks.oeb.base import OEB_DOCS, XPath, barename
-from calibre.utils.unsmarten import unsmarten_text
+from ebook_converter.ebooks.oeb.base import OEB_DOCS, XPath, barename
+from ebook_converter.utils.unsmarten import unsmarten_text
 
 
 class UnsmartenPunctuation:

--- a/ebook_converter/utils/unsmarten.py
+++ b/ebook_converter/utils/unsmarten.py
@@ -1,0 +1,40 @@
+__license__ = 'GPL 3'
+__copyright__ = '2011, John Schember <john@nachtimwald.com>'
+__docformat__ = 'restructuredtext en'
+
+from ebook_converter.utils.mreplace import MReplace
+
+_mreplace = MReplace({
+        '&#8211;': '--',
+        '&ndash;': '--',
+        '–': '--',
+        '&#8212;': '---',
+        '&mdash;': '---',
+        '—': '---',
+        '&#8230;': '...',
+        '&hellip;': '...',
+        '…': '...',
+        '&#8220;': '"',
+        '&#8221;': '"',
+        '&#8222;': '"',
+        '&#8243;': '"',
+        '&ldquo;': '"',
+        '&rdquo;': '"',
+        '&bdquo;': '"',
+        '&Prime;': '"',
+        '“':'"',
+        '”':'"',
+        '„':'"',
+        '″':'"',
+        '&#8216;':"'",
+        '&#8217;':"'",
+        '&#8242;':"'",
+        '&lsquo;':"'",
+        '&rsquo;':"'",
+        '&prime;':"'",
+        '‘':"'",
+        '’':"'",
+        '′':"'",
+})
+
+unsmarten_text = _mreplace.mreplace


### PR DESCRIPTION
Fixing issue when using unsmarten option

Example:
```
output_path = str(Path(input_path).with_suffix('.epub'))
plumber = Plumber(input_path, output_path, default_log)
plumber.merge_ui_recommendations([
    ('unsmarten_punctuation', True, OptionRecommendation.HIGH)
])
plumber.run()
```

```
    from ebook_converter.ebooks.oeb.transforms.unsmarten import UnsmartenPunctuation
ModuleNotFoundError: No module named 'ebook_converter.ebooks.oeb.transforms.unsmarten'
```