### PR TITLE
Updated so pkg_resources deprication error goes away

### DIFF
--- a/ebook_converter/__init__.py
+++ b/ebook_converter/__init__.py
@@ -1,6 +1,6 @@
 import mimetypes
-import pkg_resources
+from importlib.resources import files
 
 
-mimetypes.init([pkg_resources.
-                resource_filename('ebook_converter', 'data/mime.types')])
+mime_path = files('ebook_converter').joinpath('data/mime.types')
+mimetypes.init([str(mime_path)])

--- a/ebook_converter/ebooks/conversion/cli.py
+++ b/ebook_converter/ebooks/conversion/cli.py
@@ -7,7 +7,8 @@ import mimetypes
 import numbers
 import optparse
 import os
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
 import re
 import sys
 
@@ -351,8 +352,9 @@ def read_sr_patterns(path, log=None):
 
 def main(args=sys.argv):
     log = logging.default_log
-    mimetypes.init([pkg_resources.resource_filename('ebook_converter',
-                                                    'data/mime.types')])
+    ##mimetypes.init([pkg_resources.resource_filename('ebook_converter',
+    #                                                'data/mime.types')])
+    mimetypes.init([str(files('ebook_converter').joinpath('data/mime.types'))])
     parser, plumber = create_option_parser(args, log)
     opts, leftover_args = parser.parse_args(args)
     if len(leftover_args) > 3:

--- a/ebook_converter/ebooks/conversion/plugins/fb2_input.py
+++ b/ebook_converter/ebooks/conversion/plugins/fb2_input.py
@@ -3,7 +3,8 @@ Convert .fb2 files to .lrf
 """
 import mimetypes
 import os
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
 import re
 
 from lxml import etree
@@ -85,8 +86,9 @@ class FB2Input(InputFormatPlugin):
             css = re.sub(r'name\s*=\s*', 'class=', css)
         self.extract_embedded_content(doc)
         log.debug('Converting XML to HTML...')
-        with open(pkg_resources.resource_filename('ebook_converter',
-                                                  'data/fb2.xsl')) as f:
+        #with open(pkg_resources.resource_filename('ebook_converter',
+         #                                         'data/fb2.xsl')) as f:
+        with open(str(files('ebook_converter').joinpath('data/fb2.xsl'))) as f:
             ss = f.read()
         ss = ss.replace("__FB_NS__", fb_ns)
         if options.no_inline_fb2_toc:

--- a/ebook_converter/ebooks/conversion/plugins/html_output.py
+++ b/ebook_converter/ebooks/conversion/plugins/html_output.py
@@ -1,5 +1,6 @@
 import os
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
 import re
 import shutil
 
@@ -92,30 +93,33 @@ class HTMLOutput(OutputFormatPlugin):
             with open(opts.template_html_index, 'rb') as f:
                 template_html_index_data = f.read()
         else:
-            with open(pkg_resources.
-                      resource_filename('ebook_converter',
-                                        'data/html_export_default_index.tmpl')
-                     ) as fobj:
+            #with open(pkg_resources.
+            #          resource_filename('ebook_converter',
+            #                            'data/html_export_default_index.tmpl')
+            #         ) as fobj:
+            with open(str(files('ebook_converter').joinpath('data/html_export_default_index.tmpl'))) as fobj:
                 template_html_index_data = fobj.read().decode()
 
         if opts.template_html is not None:
             with open(opts.template_html, 'rb') as f:
                 template_html_data = f.read()
         else:
-            with open(pkg_resources.
-                      resource_filename('ebook_converter',
-                                        'data/html_export_default.tmpl')
-                     ) as fobj:
+            #with open(pkg_resources.
+            #          resource_filename('ebook_converter',
+             #                           'data/html_export_default.tmpl')
+            #         ) as fobj:
+            with open(str(files('ebook_converter').joinpath('data/html_export_default.tmpl'))) as fobj:
                 template_html_data = fobj.read().decode()
 
         if opts.template_css is not None:
             with open(opts.template_css, 'rb') as f:
                 template_css_data = f.read()
         else:
-            with open(pkg_resources.
-                      resource_filename('ebook_converter',
-                                        'data/html_export_default.css')
-                     ) as fobj:
+            #with open(pkg_resources.
+            #          resource_filename('ebook_converter',
+            #                            'data/html_export_default.css')
+            #         ) as fobj:
+            with open(str(files('ebook_converter').joinpath('data/html_export_default.css'))) as fobj:
                 template_css_data = fobj.read().decode()
 
         template_html_index_data = template_html_index_data.decode('utf-8')

--- a/ebook_converter/ebooks/conversion/plugins/lrf_input.py
+++ b/ebook_converter/ebooks/conversion/plugins/lrf_input.py
@@ -1,6 +1,7 @@
 import os
 import sys
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
 
 from lxml import etree
 
@@ -52,9 +53,10 @@ class LRFInput(InputFormatPlugin):
 
         self.log.info('Converting XML to HTML...')
 
-        with open(pkg_resources.
-                  resource_filename('ebook_converter',
-                                    'data/lrf.xsl')) as fobj:
+        #with open(pkg_resources.
+        #          resource_filename('ebook_converter',
+        #                            'data/lrf.xsl')) as fobj:
+        with open(str(files('ebook_converter').joinpath('data/lrf.xsl'))) as fobj:
             # TODO(gryf): change this nonsense to etree.parse() instead.
             styledoc = etree.fromstring(fobj.read())
         media_type = MediaType()

--- a/ebook_converter/ebooks/conversion/plugins/rtf_input.py
+++ b/ebook_converter/ebooks/conversion/plugins/rtf_input.py
@@ -1,6 +1,8 @@
 import glob
 import os
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
+
 import re
 import textwrap
 
@@ -288,8 +290,9 @@ class RTFInput(InputFormatPlugin):
 
         self.log.info('Converting XML to HTML...')
         inline_class = InlineClass(self.log)
-        with open(pkg_resources.resource_filename('ebook_converter',
-                                                  'data/rtf.xsl')) as fobj:
+        #with open(pkg_resources.resource_filename('ebook_converter',
+        #                                          'data/rtf.xsl')) as fobj:
+        with open(str(files('ebook_converter').joinpath('data/rtf.xsl'))) as fobj:
             styledoc = etree.fromstring(fobj.read())
         extensions = {('calibre', 'inline-class'): inline_class}
         transform = etree.XSLT(styledoc, extensions=extensions)

--- a/ebook_converter/ebooks/metadata/opf2.py
+++ b/ebook_converter/ebooks/metadata/opf2.py
@@ -544,7 +544,10 @@ class OPF(object):  # {{{
     xpn = NAMESPACES.copy()
     xpn.pop(None)
     xpn['re'] = 'http://exslt.org/regular-expressions'
-    XPath = functools.partial(etree.XPath, namespaces=xpn)
+
+    # Had to change because how lxml 6 deals with etree.XPath
+    #XPath = functools.partial(etree.XPath, namespaces=xpn)
+    XPath = staticmethod(lambda expr, xpn=xpn: etree.XPath(expr, namespaces=xpn))
     CONTENT = XPath('self::*[re:match(name(), "meta$", "i")]/@content')
     TEXT = XPath('string()')
 

--- a/ebook_converter/ebooks/oeb/polish/toc.py
+++ b/ebook_converter/ebooks/oeb/polish/toc.py
@@ -1,7 +1,8 @@
 import collections
 import functools
 import operator
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
 import re
 import urllib.parse
 
@@ -719,9 +720,10 @@ def commit_nav_toc(container, toc, lang=None, landmarks=None,
         if previous_nav is not None:
             root = previous_nav[1]
         else:
-            with open(pkg_resources.
-                      resource_filename('ebook_converter',
-                                        'data/new_nav.html')) as fobj:
+            #with open(pkg_resources.
+            #          resource_filename('ebook_converter',
+            #                            'data/new_nav.html')) as fobj:
+            with open(str(files('ebook_converter').joinpath('data/new_nav.html'))) as fobj:
                 root = container.parse_xhtml(fobj.read())
         container.replace(tocname, root)
     else:

--- a/ebook_converter/ebooks/oeb/stylizer.py
+++ b/ebook_converter/ebooks/oeb/stylizer.py
@@ -2,7 +2,8 @@
 CSS property propagation class.
 """
 import os, re, logging, copy, unicodedata, numbers
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
 from operator import itemgetter
 from weakref import WeakKeyDictionary
 from xml.dom import SyntaxErr as CSSSyntaxError
@@ -28,8 +29,9 @@ _html_css_stylesheet = None
 def html_css_stylesheet():
     global _html_css_stylesheet
     if _html_css_stylesheet is None:
-        with open(pkg_resources.resource_filename('ebook_converter',
-                                                  'data/html.css'), 'rb') as f:
+        #with open(pkg_resources.resource_filename('ebook_converter',
+        #                                           'data/html.css'), 'rb') as f:
+        with open(str(files('ebook_converter').joinpath('data/html.css')), 'rb') as f:
             html_css = f.read().decode('utf-8')
         _html_css_stylesheet = parseString(html_css, validate=False)
     return _html_css_stylesheet

--- a/ebook_converter/spell/__init__.py
+++ b/ebook_converter/spell/__init__.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import json
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
 
 from ebook_converter.utils.localization import canonicalize_lang
 
@@ -16,8 +17,9 @@ ccodes, ccodemap, country_names = None, None, None
 def get_codes():
     global ccodes, ccodemap, country_names
     if ccodes is None:
-        src = pkg_resources.resource_filename('ebook_converter',
-                                              'data/iso_3166-1.json')
+        src = str(files('ebook_converter').joinpath('data/iso_3166-1.json'))
+        #src = pkg_resources.resource_filename('ebook_converter',
+        #                                      'data/iso_3166-1.json')
         with open(src, 'rb') as f:
             db = json.load(f)
         codes = set()

--- a/ebook_converter/utils/config_base.py
+++ b/ebook_converter/utils/config_base.py
@@ -10,7 +10,8 @@ import pickle
 import re
 import traceback
 
-import pkg_resources
+#import pkg_resources
+from importlib.resources import files
 
 from ebook_converter.constants_old import config_dir
 from ebook_converter.constants_old import filesystem_encoding
@@ -591,8 +592,8 @@ def exec_tweaks(path):
 
 
 def default_tweaks_raw():
-    return pkg_resources.resource_filename('ebook_converter',
-                                           'data/default_tweaks.py')
+    return str(files('ebook_converter').joinpath('data/default_tweaks.py'))
+    #return pkg_resources.resource_filename('ebook_converter','data/default_tweaks.py')
 
 
 def read_tweaks():

--- a/ebook_converter/utils/localization.py
+++ b/ebook_converter/utils/localization.py
@@ -1,5 +1,6 @@
 import json
-import pkg_resources
+from importlib.resources import files
+#import pkg_resources
 
 
 def get_lang():
@@ -39,8 +40,8 @@ def _load_iso639():
     # excerpt form Calibre transform code which is executed during Calibre
     # build).
     if _iso639 is None:
-        src = pkg_resources.resource_filename('ebook_converter',
-                                              'data/iso_639-3.json')
+        src = str(files('ebook_converter').joinpath('data/iso_639-3.json'))
+        #src = pkg_resources.resource_filename('ebook_converter','data/iso_639-3.json')
 
         with open(src, 'rb') as f:
             root = json.load(f)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pip install --no-binary lxml,html5-parser .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "filelock>=3.0.12",
     "html2text>=2020.1.16",
     "html5-parser==0.4.12",
+    "lxml",
     "msgpack>=1.0.0",
     "odfpy>=1.4.1",
     "pillow>=8.0.1",
@@ -20,6 +21,7 @@ dependencies = [
     "setuptools>=61.0",
     "tinycss>=0.4"
 ]
+
 readme = "README.rst"
 authors = [
     {name = "gryf", email = "gryf73@gmail.com"}


### PR DESCRIPTION
I essentially changed all instances where we see:
`with open(pkg_resources.resource_filename('ebook_converter', 'directory/file.extension')) as f:`

To:
`with open(str(files('ebook_converter').joinpath('directory/file.extension'))) as f:`

From: 
`from importlib.resources import files`

This is just the updated way to do the exact same thing.

I also created a install.sh file due to the fact that when you try and install built wheels for lxml and html5-parser, they are built against different versions of libxml2. So to change this, you have to force pip to build them from source. I couldn't find a better way to do this. 